### PR TITLE
feat: doc_pick 문서 선택 UI 구현 및 Qdrant 재인덱싱

### DIFF
--- a/ai/agents/document_agent.py
+++ b/ai/agents/document_agent.py
@@ -69,6 +69,7 @@ async def document_agent(state: AgentState) -> AgentState:
             response_data = _handle_doc_summary(
                 user_input,
                 document_content=document_content,
+                user_id=user_id,
                 stream_mode=stream_mode,
             )
 
@@ -754,7 +755,7 @@ def _generate_proposal(user_input: str) -> Dict[str, Any]:
     }
 
 
-def _handle_doc_summary(user_input: str, document_content: str = None, stream_mode: bool = False) -> Dict[str, Any]:
+def _handle_doc_summary(user_input: str, document_content: str = None, user_id: int = None, stream_mode: bool = False) -> Dict[str, Any]:
     """문서 요약 처리"""
     _t = time.time()
     print(f"[DocumentAgent] _handle_doc_summary | content_len={len(document_content) if document_content else 0}, stream_mode={stream_mode}")
@@ -762,16 +763,23 @@ def _handle_doc_summary(user_input: str, document_content: str = None, stream_mo
     if document_content:
         print(f"[DocumentAgent] document_content 미리보기 (앞 300자):\n{document_content[:300]}")
     else:
-        print(f"[DocumentAgent] document_content가 None 또는 빈 문자열! user_input='{user_input}'")
+        print(f"[DocumentAgent] document_content 없음 → Qdrant 문서 목록 조회")
 
-    # 문서 내용이 없으면 (파일 업로드 없거나 파싱 실패) 안내 메시지 반환
-    # 주의: user_input을 document_content로 쓰면 LLM이 질문 자체를 요약해 환각이 발생함
+    # 문서 내용이 없으면 Qdrant에서 문서 목록 조회 후 doc_pick 반환
     if not document_content:
-        print("[DocumentAgent] document_content 없음 → 업로드 안내 메시지 반환")
+        print("[DocumentAgent] document_content 없음 → Qdrant 문서 목록 조회")
+        try:
+            from ai.rag.qdrant_pipeline import get_qdrant_pipeline
+            pipeline = get_qdrant_pipeline()
+            doc_list = pipeline.list_documents(source="documents", user_id=user_id)
+            print(f"[DocumentAgent] Qdrant 문서 목록 {len(doc_list)}개 조회됨")
+        except Exception as e:
+            print(f"[DocumentAgent] Qdrant 문서 목록 조회 실패: {e}")
+            doc_list = []
         return {
-            "type": "clarify",
-            "message": "요약할 문서를 찾지 못했습니다.\n\n화면의 **[📎 첨부 버튼]**을 눌러 요약할 문서(DOCX, PDF, TXT)를 업로드한 뒤 다시 요청해주세요.\n\n> 파일을 업로드했는데도 이 메시지가 뜬다면 서버 로그를 확인해주세요 (파싱 결과가 비어있을 수 있습니다).",
-            "answer": "요약할 문서를 업로드해주세요."
+            "type": "doc_pick",
+            "message": "요약할 문서를 선택해주세요:",
+            "documents": doc_list,
         }
 
     from ai.llm.prompts import DOC_SUMMARY_SYSTEM_PROMPT

--- a/ai/rag/qdrant_pipeline.py
+++ b/ai/rag/qdrant_pipeline.py
@@ -116,6 +116,10 @@ class QdrantRAGPipeline:
 
         return search_results
 
+    def list_documents(self, source: str = "documents", user_id: int = None) -> list[dict]:
+        """source 필터로 저장된 문서 목록 반환 (title + document_id)"""
+        return self.vector_store.list_documents_by_source(source=source, user_id=user_id)
+
 
 def get_qdrant_pipeline() -> QdrantRAGPipeline:
     """Qdrant RAG 파이프라인 싱글턴 인스턴스 반환"""

--- a/ai/rag/qdrant_store.py
+++ b/ai/rag/qdrant_store.py
@@ -220,6 +220,58 @@ class QdrantVectorStore:
             "metadatas": metadatas,
         }
 
+    def list_documents_by_source(self, source: str, user_id: int = None) -> list[dict]:
+        """source 필터로 Qdrant에 저장된 고유 문서 목록 전체 반환 (title + document_id)
+
+        Args:
+            source: 메타데이터 source 값 (예: "documents")
+            user_id: 사용자 ID — company 문서 + 해당 유저의 personal 문서 포함
+        Returns:
+            [{"document_id": int, "title": str}, ...]  (document_id 기준 중복 제거)
+        """
+        if self.client is None:
+            raise RuntimeError("QdrantVectorStore가 초기화되지 않았습니다.")
+
+        query_filter = Filter(
+            must=[FieldCondition(key="source", match=MatchValue(value=source))]
+        )
+
+        # offset 기반 페이지네이션으로 전체 포인트 수집
+        seen_ids = set()
+        result = []
+        offset = None
+
+        while True:
+            points, next_offset = self.client.scroll(
+                collection_name=self.collection_name,
+                scroll_filter=query_filter,
+                limit=100,
+                offset=offset,
+                with_payload=True,
+                with_vectors=False,
+            )
+
+            for point in points:
+                doc_id = point.payload.get("document_id")
+                title = point.payload.get("title", "제목 없음")
+                scope = point.payload.get("scope", "company")
+                uid = point.payload.get("user_id")
+
+                # scope 필터: company는 모두 노출, personal은 본인 것만
+                if scope == "personal":
+                    if user_id is None or str(uid) != str(user_id):
+                        continue
+
+                if doc_id and doc_id not in seen_ids:
+                    seen_ids.add(doc_id)
+                    result.append({"document_id": doc_id, "title": title})
+
+            if next_offset is None:
+                break
+            offset = next_offset
+
+        return result
+
     def delete_by_filter(self, filter_dict: dict):
         """메타데이터 필터 조건에 맞는 포인트 삭제"""
         if self.client is None:

--- a/ai/tests/reindex_documents.py
+++ b/ai/tests/reindex_documents.py
@@ -1,0 +1,180 @@
+"""
+source="documents"이지만 document_id=None인 Qdrant 포인트를 DB와 매핑하여 재인덱싱하는 스크립트
+
+실행 방법 (프로젝트 루트에서):
+    python -m ai.tests.reindex_documents
+
+동작:
+  1. Qdrant에서 source="documents" & document_id=None 포인트 수집
+  2. DB에서 status="completed" 문서 조회 → title 기준 매핑
+  3. 매핑 성공: 기존 포인트 삭제 → document_id 포함 재인덱싱
+  4. 매핑 실패(DB 없음): DB Document 레코드 신규 생성 → 인덱싱
+"""
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "backend"))
+
+from dotenv import load_dotenv
+load_dotenv()
+
+from qdrant_client import QdrantClient
+from qdrant_client.models import Filter, FieldCondition, MatchValue, PointIdsList
+
+QDRANT_URL = os.getenv("QDRANT_URL")
+QDRANT_API_KEY = os.getenv("QDRANT_API_KEY")
+COLLECTION_NAME = "documents"
+
+client = QdrantClient(url=QDRANT_URL, api_key=QDRANT_API_KEY)
+
+
+def fetch_orphaned_points() -> list:
+    """document_id=None인 source='documents' 포인트 전체 수집"""
+    source_filter = Filter(
+        must=[FieldCondition(key="source", match=MatchValue(value="documents"))]
+    )
+    all_points = []
+    offset = None
+    while True:
+        points, next_offset = client.scroll(
+            collection_name=COLLECTION_NAME,
+            scroll_filter=source_filter,
+            limit=100,
+            offset=offset,
+            with_payload=True,
+            with_vectors=False,
+        )
+        all_points.extend(points)
+        if next_offset is None:
+            break
+        offset = next_offset
+
+    return [p for p in all_points if not p.payload.get("document_id")]
+
+
+async def main():
+    from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
+    from sqlalchemy import select
+    from app.models.document import Document
+
+    DATABASE_URL = os.getenv("DATABASE_URL", "postgresql+asyncpg://postgres:password@localhost:5432/workflow_agent")
+    engine = create_async_engine(DATABASE_URL)
+    async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    # ── 1. 고아 포인트 수집 ──────────────────────────────────────────
+    print("=" * 60)
+    print("1. Qdrant 고아 포인트(document_id=None) 수집 중...")
+    orphaned = fetch_orphaned_points()
+    print(f"   고아 포인트 수: {len(orphaned)}")
+    if not orphaned:
+        print("   재인덱싱할 포인트 없음. 종료.")
+        await engine.dispose()
+        return
+
+    # title 기준으로 그룹화
+    title_to_points: dict[str, list] = {}
+    for p in orphaned:
+        title = p.payload.get("title", "")
+        title_to_points.setdefault(title, []).append(p)
+    print(f"   고유 title 수: {len(title_to_points)}")
+
+    # ── 2. DB 문서 조회 ──────────────────────────────────────────────
+    print("\n2. DB 완료 문서 조회 중...")
+    async with async_session() as session:
+        result = await session.execute(
+            select(Document).where(Document.status == "completed")
+        )
+        db_docs = result.scalars().all()
+    db_title_map = {doc.title: doc for doc in db_docs}
+    print(f"   DB 완료 문서 수: {len(db_docs)}")
+
+    # ── 3. Qdrant 파이프라인 초기화 ──────────────────────────────────
+    print("\n3. Qdrant 파이프라인 초기화 중...")
+    from ai.rag.qdrant_pipeline import get_qdrant_pipeline
+    pipeline = get_qdrant_pipeline()
+    print("   초기화 완료")
+
+    # ── 4. 매핑 및 재인덱싱 ──────────────────────────────────────────
+    print("\n4. 재인덱싱 시작...")
+    matched_count = 0
+    created_count = 0
+    skipped_count = 0
+
+    async with async_session() as session:
+        for title, points in title_to_points.items():
+            point_ids = [p.id for p in points]
+            # 대표 포인트에서 payload 추출
+            payload = points[0].payload
+            content = payload.get("content", "")
+            scope = payload.get("scope", "company")
+            uid_str = payload.get("user_id", "1")
+
+            if not content:
+                print(f"   [SKIP] '{title}' — content 없음")
+                skipped_count += 1
+                continue
+
+            # DB에서 title 매핑 시도
+            db_doc = db_title_map.get(title)
+
+            if db_doc is None:
+                # DB 레코드 없음 → 신규 생성
+                try:
+                    user_id_int = int(uid_str) if uid_str else 1
+                except ValueError:
+                    user_id_int = 1
+
+                new_doc = Document(
+                    title=title,
+                    file_path="qdrant_reimport",
+                    file_type="txt",
+                    content=content,
+                    scope=scope,
+                    uploaded_by=user_id_int,
+                    status="completed",
+                )
+                session.add(new_doc)
+                await session.flush()  # id 확보
+                db_doc = new_doc
+                created_count += 1
+                print(f"   [CREATE] '{title}' -> document_id={db_doc.id}")
+            else:
+                matched_count += 1
+                print(f"   [MATCH]  '{title}' -> document_id={db_doc.id}")
+
+            # 기존 고아 포인트 삭제
+            client.delete(
+                collection_name=COLLECTION_NAME,
+                points_selector=PointIdsList(points=point_ids),
+            )
+
+            # document_id 포함하여 재인덱싱
+            pipeline.add_documents(
+                documents=[content],
+                metadatas=[{
+                    "source": "documents",
+                    "doc_type": "general",
+                    "title": db_doc.title,
+                    "scope": db_doc.scope,
+                    "user_id": str(db_doc.uploaded_by),
+                    "document_id": db_doc.id,
+                }],
+            )
+
+        await session.commit()
+
+    # ── 5. 결과 요약 ─────────────────────────────────────────────────
+    print("\n" + "=" * 60)
+    print(f"완료!")
+    print(f"  DB 매핑 성공  : {matched_count}개")
+    print(f"  DB 레코드 신규 생성: {created_count}개")
+    print(f"  content 없어 스킵: {skipped_count}개")
+    print(f"  총 재인덱싱   : {matched_count + created_count}개")
+
+    await engine.dispose()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/app/api/v1/chat.py
+++ b/backend/app/api/v1/chat.py
@@ -346,6 +346,9 @@ async def chat_stream(request: ChatRequest, user=Depends(get_current_user), db: 
                             agent_response.pop("sys_prompt", None)
                             agent_response.pop("user_prompt", None)
                             final_state["agent_response"] = agent_response
+                        elif agent_response.get("type") == "doc_pick":
+                            # doc_pick: document_agent에서 Qdrant 목록 이미 채워서 옴 — 그대로 사용
+                            print(f"[Chat] doc_pick: 문서 {len(agent_response.get('documents', []))}개")
                         else:
                             yield f"data: {json.dumps({'type': 'status', 'value': 'document_agent 처리 완료'}, ensure_ascii=False)}\n\n"
 

--- a/docs/logs/ai-승언.md
+++ b/docs/logs/ai-승언.md
@@ -153,3 +153,47 @@
 3. 전체 E2E 동작 확인 (로그인 → 채팅 → RAG 검색)
 
 ---
+
+## 2026-02-24 (월)
+
+### 작업 내용
+
+#### 1. 문서 요약 (doc_summary) 환각 버그 수정
+- **원인 1**: `_extract_docx`가 `doc.paragraphs`만 순회, 테이블 내용 누락
+- **수정**: `doc.tables` 순회 추가 + 빈 단락 필터링 + 디버그 print 추가
+- **원인 2**: `_handle_doc_summary`에서 `document_content` 없을 때 `user_input` fallback 사용 → LLM이 짧은 쿼리를 문서로 인식해 환각 생성
+- **수정**: `user_input` fallback 완전 제거, 대신 `doc_pick` 마커 반환
+- **파일**: `backend/app/services/document_service.py`, `ai/agents/document_agent.py`
+
+#### 2. Intent 신뢰도 임계값 하향 조정
+- **문제**: confidence 0.8인 의도도 clarify UI 재질문 발생
+- **수정**: `INTENT_CONFIDENCE_THRESHOLD` 0.85 → 0.75
+- **파일**: `ai/agents/config.py`
+
+#### 3. doc_pick 기능 구현 (문서 선택 UI)
+- **기능**: 파일 업로드 없이 문서 요약 요청 시 Qdrant 문서 목록 리스트 표시, 선택 시 해당 문서 요약 진행
+- **구현**:
+  - `_handle_doc_summary`: `document_content` 없을 때 `get_qdrant_pipeline().list_documents()` 호출 → `doc_pick` 타입 반환
+  - `chat.py`: `doc_pick` 타입 수신 시 Qdrant 목록 그대로 사용 (DB 조회 제거)
+  - `ChatPage.jsx`: `doc_pick` case 추가 — 문서 버튼 클릭 시 `setSelectedDocument` + `onSelectClarify` 호출, `max-h-64 overflow-y-auto` 스크롤 적용
+- **파일**: `ai/agents/document_agent.py`, `backend/app/api/v1/chat.py`, `frontend/src/pages/ChatPage.jsx`
+
+#### 4. Qdrant `list_documents_by_source` 구현
+- offset 기반 페이지네이션으로 전체 포인트 수집
+- `document_id` 기준 중복 제거 (청크 → 고유 문서)
+- `scope="personal"` 문서는 본인 것만 포함 (`user_id` 필터)
+- **파일**: `ai/rag/qdrant_store.py`, `ai/rag/qdrant_pipeline.py`
+
+#### 5. Qdrant document_id=None 포인트 재인덱싱
+- **문제**: `seed_sample_documents.py`가 Qdrant 직접 저장 시 `document_id` 미포함 → `list_documents_by_source`에서 스킵됨
+- **원인 분석**: 86개 포인트 중 83개 `document_id=None`, 3개만 유효 (UI 업로드 경로만 `document_id` 포함)
+- **해결**: `ai/tests/reindex_documents.py` 스크립트 작성 및 실행 → 19개 문서 DB 신규 생성 + Qdrant 재인덱싱 완료 (document_id 22~40)
+- **파일**: `ai/tests/reindex_documents.py` (신규)
+
+### 다음 할 일
+
+1. **doc_pick 선택 후 요약 플로우 검증** — 선택한 문서가 실제로 요약되는지 E2E 확인
+2. **clarify 플로우 state 손실 문제 해결** — clarify 선택 시 원본 쿼리 및 `document_id` 유실 문제
+3. **doc_qa 검색 품질 개선** — Qdrant RAG 검색 결과 정확도 확인
+
+---

--- a/frontend/src/pages/ChatPage.jsx
+++ b/frontend/src/pages/ChatPage.jsx
@@ -252,6 +252,36 @@ function renderCardMessage(msg, onSelectClarify, onSelectDoc, messages = [], ind
       );
     }
 
+    case 'doc_pick': {
+      const documents = data.documents || [];
+      // 이 assistant 메시지 바로 앞의 user 메시지가 원본 쿼리
+      const originalQuery = index > 0 ? (messages[index - 1]?.content || '요약해줘') : '요약해줘';
+      return (
+        <div>
+          <div className="bg-surface-card border border-neutral-border rounded-2xl rounded-bl-sm p-4 text-sm text-neutral-main leading-relaxed">
+            {data.message || '요약할 문서를 선택해주세요:'}
+          </div>
+          {documents.length > 0 && (
+            <div className="mt-2 flex flex-col gap-2 max-h-64 overflow-y-auto pr-1">
+              {documents.map((doc, idx) => (
+                <button
+                  key={idx}
+                  onClick={() => {
+                    useChatStore.getState().setSelectedDocument(doc.document_id, doc.title);
+                    onSelectClarify?.(originalQuery);
+                  }}
+                  className="flex items-center gap-2 px-4 py-2.5 text-sm bg-surface-card border border-neutral-border rounded-xl hover:bg-primary-50 hover:border-primary-300 text-neutral-main hover:text-primary-700 transition text-left"
+                >
+                  <FileText size={14} className="flex-shrink-0 text-neutral-muted" />
+                  <span className="truncate">{doc.title}</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      );
+    }
+
     case 'clarify': {
       const candidates = data.candidates || [];
       return (


### PR DESCRIPTION
- doc_summary 환각 버그 수정: _extract_docx 테이블 파싱 추가, user_input fallback 제거
- doc_pick 기능: 파일 업로드 없이 요약 요청 시 Qdrant 문서 목록 표시 후 선택
- list_documents_by_source: offset 페이지네이션 + document_id 중복 제거 구현
- INTENT_CONFIDENCE_THRESHOLD 0.85 → 0.75 하향
- ChatPage doc_pick UI: 스크롤 가능한 문서 선택 리스트 (max-h-64)
- reindex_documents.py: document_id=None 고아 포인트 DB 매핑 재인덱싱 스크립트
- 작업 로그 업데이트 (ai-승언.md)