### PR TITLE
fix: AWS RDS에 없는 document_id 선택 시 doc_pick 무한 루프 수정

### DIFF
--- a/ai/rag/qdrant_pipeline.py
+++ b/ai/rag/qdrant_pipeline.py
@@ -120,6 +120,11 @@ class QdrantRAGPipeline:
         """source 필터로 저장된 문서 목록 반환 (title + document_id)"""
         return self.vector_store.list_documents_by_source(source=source, user_id=user_id)
 
+    def get_document_content(self, document_id: int) -> str:
+        """document_id로 Qdrant 청크 전체 합산 → 전체 content 반환 (DB 없을 때 fallback용)"""
+        chunks = self.vector_store.get_chunks_by_document_id(document_id)
+        return "\n\n".join(chunks) if chunks else ""
+
 
 def get_qdrant_pipeline() -> QdrantRAGPipeline:
     """Qdrant RAG 파이프라인 싱글턴 인스턴스 반환"""

--- a/ai/rag/qdrant_store.py
+++ b/ai/rag/qdrant_store.py
@@ -272,6 +272,39 @@ class QdrantVectorStore:
 
         return result
 
+    def get_chunks_by_document_id(self, document_id: int) -> list[str]:
+        """document_id로 Qdrant 청크 전체 수집 (순서대로 content 반환)
+
+        Args:
+            document_id: DB Document.id 값
+        Returns:
+            청크 content 리스트 (삽입 순서대로)
+        """
+        if self.client is None:
+            raise RuntimeError("QdrantVectorStore가 초기화되지 않았습니다.")
+
+        query_filter = Filter(
+            must=[FieldCondition(key="document_id", match=MatchValue(value=document_id))]
+        )
+
+        all_points = []
+        offset = None
+        while True:
+            points, next_offset = self.client.scroll(
+                collection_name=self.collection_name,
+                scroll_filter=query_filter,
+                limit=100,
+                offset=offset,
+                with_payload=True,
+                with_vectors=False,
+            )
+            all_points.extend(points)
+            if next_offset is None:
+                break
+            offset = next_offset
+
+        return [p.payload.get("content", "") for p in all_points if p.payload.get("content")]
+
     def delete_by_filter(self, filter_dict: dict):
         """메타데이터 필터 조건에 맞는 포인트 삭제"""
         if self.client is None:

--- a/backend/app/api/v1/chat.py
+++ b/backend/app/api/v1/chat.py
@@ -93,6 +93,20 @@ async def chat_stream(request: ChatRequest, user=Depends(get_current_user), db: 
                         else:
                             print(f"[Chat] document_content 앞 200자:\n{doc.content[:200]}")
                         initial_state["document_content"] = doc.content or None
+                    else:
+                        # DB에 없으면 Qdrant 청크 합산 fallback (로컬 reindex로 생긴 ID가 AWS RDS에 없을 때)
+                        print(f"[Chat] document_id={request.document_id} DB에 없음 → Qdrant fallback 시도")
+                        try:
+                            from ai.rag.qdrant_pipeline import get_qdrant_pipeline
+                            pipeline = get_qdrant_pipeline()
+                            content = pipeline.get_document_content(request.document_id)
+                            if content:
+                                print(f"[Chat] Qdrant fallback 성공 ({len(content)}자)")
+                                initial_state["document_content"] = content
+                            else:
+                                print(f"[Chat] Qdrant fallback 실패: content 없음")
+                        except Exception as qdrant_err:
+                            print(f"[Chat] Qdrant fallback 실패: {qdrant_err}")
                 except Exception as doc_err:
                     print(f"[Chat] document_id 로딩 실패: {doc_err}")
 


### PR DESCRIPTION
- DB에 document가 없을 때 Qdrant 청크 합산 fallback 추가 (chat.py)
- QdrantVectorStore.get_chunks_by_document_id() 메서드 추가
- QdrantRAGPipeline.get_document_content() 메서드 추가

로컬 reindex로 생성된 document_id(22-40)가 AWS RDS에 없어
doc_pick → 요약 요청 → doc_pick 재반복 되던 문제 해결