### PR TITLE
fix: 일정 삭제 기능 구현 - 쓰레기통 버튼 + Not Found 해결

### DIFF
--- a/backend/app/api/v1/calendar.py
+++ b/backend/app/api/v1/calendar.py
@@ -1,7 +1,7 @@
 """
 Google Calendar 연동 API (팀원 D 담당)
 """
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_current_user
@@ -35,6 +35,20 @@ async def sync_to_google(
     """앱 일정 → Google Calendar 동기화 (Push)"""
     result = await calendar_service.push_event(db, current_user.id, event_data)
     return result
+
+
+@router.delete("/events/{event_id}", status_code=204)
+async def delete_google_event(
+    event_id: str,
+    calendar_id: str = Query("primary"),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Google Calendar 이벤트 삭제"""
+    try:
+        await calendar_service.delete_event(db, current_user.id, event_id, calendar_id)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
 
 
 @router.post("/event-with-meet", response_model=EventWithMeetResponse)

--- a/backend/app/services/calendar_service.py
+++ b/backend/app/services/calendar_service.py
@@ -124,6 +124,7 @@ class GoogleCalendarService(GoogleBaseService):
                     for item in items:
                         events.append({
                             "event_id": item["id"],
+                            "calendar_id": cal_id,
                             "title": item.get("summary", ""),
                             "start": item["start"].get("dateTime", item["start"].get("date")),
                             "end": item["end"].get("dateTime", item["end"].get("date")),
@@ -136,3 +137,32 @@ class GoogleCalendarService(GoogleBaseService):
         except Exception:
             raise
         return events
+
+    async def delete_event(self, db: AsyncSession, user_id: int, event_id: str, calendar_id: str = "primary") -> None:
+        """Google Calendar 이벤트 삭제 (지정 캘린더 실패 시 전체 캘린더 탐색)"""
+        creds = await self.get_credentials(db, user_id)
+        service = self._build_service(creds)
+
+        # 1차 시도: 전달받은 calendar_id로 삭제
+        try:
+            service.events().delete(calendarId=calendar_id, eventId=event_id).execute()
+            return
+        except Exception:
+            pass
+
+        # 2차 시도: 전체 캘린더 순회
+        try:
+            calendar_list = service.calendarList().list().execute()
+            for cal in calendar_list.get("items", []):
+                cal_id = cal["id"]
+                if cal_id == calendar_id:
+                    continue  # 이미 시도한 캘린더 건너뜀
+                try:
+                    service.events().delete(calendarId=cal_id, eventId=event_id).execute()
+                    return
+                except Exception:
+                    continue
+        except Exception:
+            pass
+
+        raise ValueError(f"이벤트를 찾을 수 없습니다: {event_id}")

--- a/frontend/src/api/google.js
+++ b/frontend/src/api/google.js
@@ -76,3 +76,6 @@ export const createEventWithMeet = (data) =>
 
 export const syncEventToGoogle = (eventData) =>
   client.post('/calendar/sync', eventData)
+
+export const deleteCalendarEvent = (eventId, calendarId = 'primary') =>
+  client.delete(`/calendar/events/${eventId}`, { params: { calendar_id: calendarId } })

--- a/frontend/src/components/schedules/CalendarView.jsx
+++ b/frontend/src/components/schedules/CalendarView.jsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
+import { Trash2 } from 'lucide-react';
 import MeetLinkBadge from './MeetLinkBadge';
 import useScheduleTypeStore, { DEFAULT_TYPES } from '../../store/scheduleTypeStore';
 
@@ -83,8 +84,9 @@ function getKoreanHolidays(year) {
   return [...fixed, ...lunar].map((h) => ({ ...h, type: 'holiday' }));
 }
 
-function DayDetailPopup({ day, month, year, events, typeColorMap, typeLabelMap, onClose }) {
+function DayDetailPopup({ day, month, year, events, typeColorMap, typeLabelMap, onClose, onDeleteEvent }) {
   const ref = useRef(null);
+  const [deletingId, setDeletingId] = useState(null);
 
   useEffect(() => {
     const handleClick = (e) => {
@@ -93,6 +95,17 @@ function DayDetailPopup({ day, month, year, events, typeColorMap, typeLabelMap, 
     document.addEventListener('mousedown', handleClick);
     return () => document.removeEventListener('mousedown', handleClick);
   }, [onClose]);
+
+  const handleDelete = async (eventId, calendarId) => {
+    setDeletingId(eventId);
+    try {
+      await onDeleteEvent(eventId, calendarId);
+    } catch {
+      // 삭제 실패 시 버튼 원복
+    } finally {
+      setDeletingId(null);
+    }
+  };
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/20">
@@ -112,6 +125,7 @@ function DayDetailPopup({ day, month, year, events, typeColorMap, typeLabelMap, 
               {events.map((e, i) => {
                 const dotColor = typeColorMap[e.type] || '#9CA3AF';
                 const typeLabel = typeLabelMap[e.type] || e.type;
+                const isDeleting = deletingId === e.id;
                 return (
                   <li key={i} className="flex gap-3 items-start">
                     <span
@@ -126,6 +140,20 @@ function DayDetailPopup({ day, month, year, events, typeColorMap, typeLabelMap, 
                       </div>
                       {e.meetLink && <div className="mt-1"><MeetLinkBadge meetLink={e.meetLink} /></div>}
                     </div>
+                    {e.id && onDeleteEvent && (
+                      <button
+                        onClick={() => handleDelete(e.id, e.calendarId)}
+                        disabled={isDeleting}
+                        className="shrink-0 w-7 h-7 flex items-center justify-center rounded hover:bg-error-bg text-neutral-muted hover:text-error transition disabled:opacity-40"
+                        aria-label="일정 삭제"
+                        title="일정 삭제"
+                      >
+                        {isDeleting
+                          ? <span className="w-3.5 h-3.5 border-2 border-error border-t-transparent rounded-full animate-spin" />
+                          : <Trash2 size={14} />
+                        }
+                      </button>
+                    )}
                   </li>
                 );
               })}
@@ -192,7 +220,7 @@ function YearView({ year, events, todayYear, todayMonth, todayDate, onMonthClick
   );
 }
 
-export default function CalendarView({ events = [] }) {
+export default function CalendarView({ events = [], onDeleteEvent }) {
   const now = new Date();
   const [currentYear, setCurrentYear] = useState(now.getFullYear());
   const [currentMonth, setCurrentMonth] = useState(now.getMonth() + 1);
@@ -410,6 +438,7 @@ export default function CalendarView({ events = [] }) {
           typeColorMap={typeColorMap}
           typeLabelMap={typeLabelMap}
           onClose={() => setSelectedDay(null)}
+          onDeleteEvent={onDeleteEvent}
         />
       )}
     </div>

--- a/frontend/src/pages/SchedulesPage.jsx
+++ b/frontend/src/pages/SchedulesPage.jsx
@@ -12,7 +12,7 @@ import useScheduleTypeStore, { DEFAULT_TYPES } from '../store/scheduleTypeStore'
 
 export default function SchedulesPage() {
   const { isScrolled } = useOutletContext();
-  const { connected, calendarEvents, calendarLoading, calendarError, fetchCalendarEvents, hasScope, syncEventToGoogle, createEventWithMeet } = useGoogleServices();
+  const { connected, calendarEvents, calendarLoading, calendarError, fetchCalendarEvents, hasScope, syncEventToGoogle, createEventWithMeet, deleteCalendarEvent } = useGoogleServices();
   const { customTypes } = useScheduleTypeStore();
   const [showForm, setShowForm] = useState(false);
   const [showTypeManager, setShowTypeManager] = useState(false);
@@ -40,6 +40,8 @@ export default function SchedulesPage() {
         : null;
 
       return {
+        id: event.event_id,
+        calendarId: event.calendar_id,
         month: start.getMonth() + 1,
         day: start.getDate(),
         type: 'google',
@@ -186,7 +188,7 @@ export default function SchedulesPage() {
             </div>
           ) : (
             <>
-              <CalendarView events={events} />
+              <CalendarView events={events} onDeleteEvent={deleteCalendarEvent} />
               {!connected && (
                 <div className="mt-5 p-4 bg-warning-bg border border-warning rounded-md text-center">
                   <p className="text-sm text-warning font-medium">

--- a/frontend/src/store/googleStore.js
+++ b/frontend/src/store/googleStore.js
@@ -199,6 +199,18 @@ const useGoogleStore = create((set, get) => ({
       set({ calendarError: err.response?.data?.detail || '이벤트 동기화 실패' })
     }
   },
+
+  deleteCalendarEvent: async (eventId, calendarId = 'primary') => {
+    try {
+      await googleApi.deleteCalendarEvent(eventId, calendarId)
+      set((state) => ({
+        calendarEvents: state.calendarEvents.filter((e) => e.event_id !== eventId),
+      }))
+    } catch (err) {
+      set({ calendarError: err.response?.data?.detail || '이벤트 삭제 실패' })
+      throw err
+    }
+  },
 }))
 
 export default useGoogleStore


### PR DESCRIPTION
## Summary
- 일정 관리 페이지 날짜 팝업에 쓰레기통(Trash2) 삭제 버튼 추가
- Google Calendar 이벤트 삭제 시 `calendar_id` 불일치로 발생하던 Not Found 버그 수정
- 백엔드 `DELETE /calendar/events/{event_id}` 엔드포인트 신규 추가

## 변경 파일
- `frontend/src/components/schedules/CalendarView.jsx` — DayDetailPopup 각 일정 우측에 삭제 버튼
- `frontend/src/pages/SchedulesPage.jsx` — event_id, calendar_id 매핑 추가
- `frontend/src/store/googleStore.js` — deleteCalendarEvent 액션 추가
- `frontend/src/api/google.js` — deleteCalendarEvent API 추가
- `backend/app/api/v1/calendar.py` — DELETE 엔드포인트 추가
- `backend/app/services/calendar_service.py` — delete_event 메서드 (전체 캘린더 탐색)

## Test plan
- [ ] 일정 관리 페이지 접속
- [ ] 일정 있는 날짜 클릭 → 팝업 확인
- [ ] 일정 우측 쓰레기통 버튼 클릭 → 삭제 확인 (팝업에서 즉시 사라짐)
- [ ] Google Calendar에서도 삭제되었는지 확인
- [ ] 공휴일에는 버튼이 없음을 확인

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)